### PR TITLE
typo in linux build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You will need the following libraries (and their dependencies):
 Open a terminal window, navigate to the PCem directory then enter:
 ### Linux
 ```
-./configure --enable-release
+./configure --enable-release-build
 make
 ```
 ### BSD


### PR DESCRIPTION
missing "-build" from "--enable-release-build" option of "./configure"