### PR TITLE
Configure: pick up flags from the command line

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,12 +27,12 @@ AC_MSG_CHECKING([whether to enable debugging])
 AC_ARG_ENABLE(debug,
           AC_HELP_STRING([--enable-debug], [build debug executable]))
 if test "$enable_debug" = "yes"; then
-   CFLAGS="-Wall -O0 -g -D_DEBUG -fcommon"
-   CXXFLAGS="-Wall -O0 -g -D_DEBUG -fcommon"
+   CFLAGS="$CFLAGS -Wall -O0 -g -D_DEBUG -fcommon"
+   CXXFLAGS="$CXXFLAGS -Wall -O0 -g -D_DEBUG -fcommon"
    AC_MSG_RESULT([yes])
 else
-   CFLAGS="-O3 -fcommon"
-   CXXFLAGS="-O3 -fcommon"
+   CFLAGS="$CFLAGS -O3 -fcommon"
+   CXXFLAGS="$CXXFLAGS -O3 -fcommon"
    AC_MSG_RESULT([no])
 fi
 


### PR DESCRIPTION
Allow configure to pick up `CFLAGS` and `CXXFLAGS` from the command line.

Note: configure will need to be regenerated.