### PR TITLE
Use GitHub Actions to compile PCem

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,7 +16,7 @@ jobs:
           os: ubuntu-latest
           args: --enable-networking --enable-release-build
           artifacts_name: PCem-Ubuntu-${{ github.head_ref }}-${{ github.run_number }}
-          artifacts_path: PCem.tar
+          artifacts_path: PCem.tar.bz2
           installdeps: >-
             libsdl2-dev
             libopenal-dev
@@ -167,7 +167,7 @@ jobs:
       run: |
         cp ./temp/src/pcem.exe dist
         cd dist
-        zip ${{ matrix.artifacts_path }} *
+        zip -9 ${{ matrix.artifacts_path }} *
 
     - name: prepare-package (Linux)
       if: runner.os == 'Linux'
@@ -191,7 +191,7 @@ jobs:
       run: |
        cp ./temp/src/pcem dist
        cd dist
-       tar -czf ${{ matrix.artifacts_path }} *
+       tar -cjf ${{ matrix.artifacts_path }} *
 
     - name: "Upload GitHub Actions artifacts"
       uses: actions/upload-artifact@v2

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -85,8 +85,8 @@ jobs:
        cd npcap-sdk-1.05
        cp -r Include/* /mingw32/include/
        cp -r Include/* /mingw64/include/
-       cp -r Lib/* /mingw32/lib/
-       cp -r Lib/* /mingw64/lib/
+       cp -r Lib/*.lib /mingw32/lib/
+       cp -r Lib/x64/*.lib /mingw64/lib/
     - name: Setup ubuntu dependencies
       if: runner.os == 'Linux'
       run: |
@@ -167,7 +167,7 @@ jobs:
       run: |
         cp ./temp/src/pcem.exe dist
         cd dist
-        zip -9 ${{ matrix.artifacts_path }} *
+        zip -r -9 ${{ matrix.artifacts_path }} *
 
     - name: prepare-package (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,201 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: Ubuntu 64bit (gcc)
+          os: ubuntu-latest
+          args: --enable-networking --enable-release-build
+          artifacts_name: PCem-Ubuntu-${{ github.head_ref }}-${{ github.run_number }}
+          artifacts_path: PCem.tar
+          installdeps: >-
+            libsdl2-dev
+            libopenal-dev
+            libwxgtk3.0-gtk3-dev
+            libncap-dev
+        - name: Windows 32bits (MSYS2)
+          os: windows-latest
+          compiler: MINGW32
+          args: --enable-networking --enable-release-build
+          artifacts_name: PCem-Windows-MINGW32-${{ github.head_ref }}-${{ github.run_number }}
+          artifacts_path: PCem.zip
+          installdeps: >-
+            base-devel
+            zip
+            unzip
+            mingw-w64-i686-ntldd-git
+            mingw-w64-i686-toolchain 
+            mingw-w64-i686-SDL2 
+            mingw-w64-i686-openal 
+            mingw-w64-i686-wxWidgets
+        - name: Windows 64bits (MSYS2)
+          os: windows-latest
+          compiler: MINGW64
+          args: --enable-networking --enable-release-build
+          artifacts_name: PCem-Windows-MINGW64-${{ github.head_ref }}-${{ github.run_number }}
+          artifacts_path: PCem.zip
+          installdeps: >-
+            base-devel
+            zip
+            unzip
+            mingw-w64-x86_64-ntldd-git
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-SDL2
+            mingw-w64-x86_64-openal
+            mingw-w64-x86_64-wxWidgets
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.name }}
+    
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: temp
+        fetch-depth: 0
+
+    - name: Setup MSYS2 (Windows)
+      if: runner.os == 'Windows'
+      # You may pin to the exact commit or the version.
+      # uses: msys2/setup-msys2@a43b8403533fffe0c157dd8498f021ddec66bff7
+      uses: msys2/setup-msys2@v2
+      with:
+        # Variant of the environment to set by default: MSYS, MINGW32, MINGW64, UCRT64 or CLANG64
+        msystem: ${{ matrix.compiler }}
+        # Retrieve and extract base installation from upstream GitHub Releases
+        release: false # optional, default is true
+        # Update MSYS2 installation through pacman
+        update: false
+        # Install packages after installation through pacman
+        install: ${{ matrix.installdeps }}
+    - name: npcap download (Windows)
+      if: runner.os == 'Windows'
+      shell: msys2 {0}
+      run: |
+       wget https://nmap.org/npcap/dist/npcap-sdk-1.05.zip
+       unzip -d npcap-sdk-1.05/ npcap-sdk-1.05.zip
+       cd npcap-sdk-1.05
+       cp -r Include/* /mingw32/include/
+       cp -r Include/* /mingw64/include/
+       cp -r Lib/* /mingw32/lib/
+       cp -r Lib/* /mingw64/lib/
+    - name: Setup ubuntu dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install ${{ matrix.installdeps }}
+
+    # Copy all the sources to the dist folder, before we start generating intermediate files.
+    - name: prepare-package (Windows32)
+      if: runner.os == 'Windows' && matrix.compiler == 'MINGW32'
+      shell: msys2 {0}
+      run: |
+        mkdir dist
+        cp -R ./temp/* dist
+        rm -Rf ./dist/.git
+        cp /mingw32/bin/libdeflate.dll dist
+        cp /mingw32/bin/libexpat-1.dll dist
+        cp /mingw32/bin/libgcc_s_dw2-1.dll dist
+        cp /mingw32/bin/libjpeg-8.dll dist
+        cp /mingw32/bin/liblzma-5.dll dist
+        cp /mingw32/bin/libopenal-1.dll dist
+        cp /mingw32/bin/libpng16-16.dll dist
+        cp /mingw32/bin/libstdc++-6.dll dist
+        cp /mingw32/bin/libtiff-5.dll dist
+        cp /mingw32/bin/libwebp-7.dll dist
+        cp /mingw32/bin/libwinpthread-1.dll dist
+        cp /mingw32/bin/libzstd.dll dist
+        cp /mingw32/bin/SDL2.dll dist
+        cp /mingw32/bin/wxbase30u_gcc_custom.dll dist
+        cp /mingw32/bin/wxbase30u_xml_gcc_custom.dll dist
+        cp /mingw32/bin/wxmsw30u_adv_gcc_custom.dll dist
+        cp /mingw32/bin/wxmsw30u_core_gcc_custom.dll dist
+        cp /mingw32/bin/wxmsw30u_html_gcc_custom.dll dist
+        cp /mingw32/bin/wxmsw30u_xrc_gcc_custom.dll dist
+        cp /mingw32/bin/zlib1.dll dist
+    - name: prepare-package (Windows64)
+      if: runner.os == 'Windows' && matrix.compiler == 'MINGW64'
+      shell: msys2 {0}
+      run: |
+        mkdir dist
+        cp -R ./temp/* dist
+        rm -Rf ./dist/.git
+        cp /mingw64/bin/libdeflate.dll dist
+        cp /mingw64/bin/libexpat-1.dll dist
+        cp /mingw64/bin/libgcc_s_seh-1.dll dist
+        cp /mingw64/bin/libjpeg-8.dll dist
+        cp /mingw64/bin/liblzma-5.dll dist
+        cp /mingw64/bin/libopenal-1.dll dist
+        cp /mingw64/bin/libpng16-16.dll dist
+        cp /mingw64/bin/libstdc++-6.dll dist
+        cp /mingw64/bin/libtiff-5.dll dist
+        cp /mingw64/bin/libwebp-7.dll dist
+        cp /mingw64/bin/libwinpthread-1.dll dist
+        cp /mingw64/bin/libzstd.dll dist
+        cp /mingw64/bin/SDL2.dll dist
+        cp /mingw64/bin/wxbase30u_gcc_custom.dll dist
+        cp /mingw64/bin/wxbase30u_xml_gcc_custom.dll dist
+        cp /mingw64/bin/wxmsw30u_adv_gcc_custom.dll dist
+        cp /mingw64/bin/wxmsw30u_core_gcc_custom.dll dist
+        cp /mingw64/bin/wxmsw30u_html_gcc_custom.dll dist
+        cp /mingw64/bin/wxmsw30u_xrc_gcc_custom.dll dist
+        cp /mingw64/bin/zlib1.dll dist
+    - name: configure (Windows)
+      if: runner.os == 'Windows'
+      shell: msys2 {0}
+      run: |
+        cd temp
+        autoreconf -i
+        ./configure ${{ matrix.args }}
+    - name: make (Windows)
+      if: runner.os == 'Windows'
+      shell: msys2 {0}
+      run: |
+        cd temp
+        make -j
+    - name: package (Windows)
+      if: runner.os == 'Windows'
+      shell: msys2 {0}
+      run: |
+        cp ./temp/src/pcem.exe dist
+        cd dist
+        zip ${{ matrix.artifacts_path }} *
+
+    - name: prepare-package (Linux)
+      if: runner.os == 'Linux'
+      run: |
+       mkdir dist
+       cp -R ./temp/* dist
+       rm -Rf ./dist/.git
+    - name: configure (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        cd temp
+        autoreconf -i
+        ./configure ${{ matrix.args }}
+    - name: make (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        cd temp
+        make -j
+    - name: package (Linux)
+      if: runner.os == 'Linux'
+      run: |
+       cp ./temp/src/pcem dist
+       cd dist
+       tar -czf ${{ matrix.artifacts_path }} *
+
+    - name: "Upload GitHub Actions artifacts"
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.artifacts_name }}
+        path: ./dist/${{ matrix.artifacts_path }}
+


### PR DESCRIPTION
This PR adds a configuration file so that commits to master and Pull requests to master get compiled automatically.

Here it can be seen how the result looks like: https://github.com/JosepMaJAZ/pcem/actions
Once this is merged, that will be available on https://github.com/sarah-walker-pcem/pcem/actions

The file is not too difficult to understand: it has an initial part where it defines the different platforms that it will use, and then it has a sequence of actions, some of them conditionally executed. (It prepares msys2 dependencies on windows, but updates apt dependencies on ubuntu)
Adding macOS should be quite similar, but I just didn't have a guide to follow in order to add it.

Once the task finishes, artifacts can be downloaded from the job run ( like in https://github.com/JosepMaJAZ/pcem/actions/runs/877038041 ) . 
The packaging is manually done in the file, but further improvements could use "make dist" or something else and simplify the file.