### PR TITLE
Update x86seg.c

### DIFF
--- a/src/x86seg.c
+++ b/src/x86seg.c
@@ -3058,7 +3058,7 @@ void x86_smi_enter(void)
         {
                 uint32_t base;
 
-                if (!cyrix.smhr & SMHR_VALID)
+                if (!(cyrix.smhr & SMHR_VALID))
                         cyrix.smhr = (cyrix.arr[3].base + cyrix.arr[3].size) | SMHR_VALID;
                 base = cyrix.smhr & SMHR_ADDR_MASK;
 


### PR DESCRIPTION
Evaluates the bitwise operator first.
This fixes a warning in Clang: "logical not is only applied to the left hand side of this bitwise operator [-Wlogical-not-parentheses]"