### PR TITLE
Add .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ config.status
 .dirstamp
 /pcem
 /src/pcem
+.DS_Store


### PR DESCRIPTION
.DS_Store files are created by macOS and is mainly used for Finder window positions.