### PR TITLE
Use ftruncate(2) on linux platform

### DIFF
--- a/src/wx-config.c
+++ b/src/wx-config.c
@@ -1,6 +1,6 @@
 #ifdef __linux__
   #define _GNU_SOURCE
-  #include <linux/falloc.h>
+  #include <fcntl.h>
 #endif
 
 #include "wx-utils.h"

--- a/src/wx-config.c
+++ b/src/wx-config.c
@@ -1569,7 +1569,7 @@ static int create_drive_raw(void* data)
         FILE* f = (FILE*)data;
 
         #ifdef __linux__
-          if(fallocate(fdopen(f), FALLOC_FL_ZERO_RANGE, 0, (hd_new_cyl * hd_new_hpc * hd_new_spt) ) == 0)) {
+          if(fallocate(fdopen(f, "w+"), FALLOC_FL_ZERO_RANGE, 0, (hd_new_cyl * hd_new_hpc * hd_new_spt) ) == 0)) {
             create_drive_pos = (hd_new_cyl * hd_new_hpc * hd_new_spt);
             return 1;
           }

--- a/src/wx-config.c
+++ b/src/wx-config.c
@@ -1575,7 +1575,8 @@ static int create_drive_raw(void* data)
         FILE* f = (FILE*)data;
 
         #ifdef __linux__
-          if((fallocate64(fileno(f), FALLOC_FL_ZERO_RANGE, 0, c_max * 512)) == 0) {
+          off64_t len = ((off64_t)c_max)*512;
+          if((fallocate(fileno(f), FALLOC_FL_ZERO_RANGE, 0, len)) == 0) {
             create_drive_pos = c_max;
             return 1;
           }

--- a/src/wx-config.c
+++ b/src/wx-config.c
@@ -1574,7 +1574,7 @@ static int create_drive_raw(void* data)
         FILE* f = (FILE*)data;
 
         #ifdef __linux__
-          if((fallocate(fileno(f), FALLOC_FL_ZERO_RANGE, 0, (hd_new_cyl * hd_new_hpc * hd_new_spt))) == 0) {
+          if((fallocate(fileno(f), FALLOC_FL_ZERO_RANGE, 0, (off64_t) (hd_new_cyl * hd_new_hpc * hd_new_spt) * 512)) == 0) {
             create_drive_pos = (hd_new_cyl * hd_new_hpc * hd_new_spt);
             return 1;
           }

--- a/src/wx-config.c
+++ b/src/wx-config.c
@@ -1,3 +1,6 @@
+// Enable glibc extensions
+#define _GNU_SOURCE
+
 #include "wx-utils.h"
 #include "wx-sdl2.h"
 #include "wx-joystickconfig.h"
@@ -1569,7 +1572,7 @@ static int create_drive_raw(void* data)
         FILE* f = (FILE*)data;
 
         #ifdef __linux__
-          if(fallocate(fdopen(f, "w+"), FALLOC_FL_ZERO_RANGE, 0, (hd_new_cyl * hd_new_hpc * hd_new_spt) ) == 0)) {
+          if(fallocate(fdopen(f, "w+"), FALLOC_FL_ZERO_RANGE, 0, (hd_new_cyl * hd_new_hpc * hd_new_spt)) == 0) {
             create_drive_pos = (hd_new_cyl * hd_new_hpc * hd_new_spt);
             return 1;
           }

--- a/src/wx-config.c
+++ b/src/wx-config.c
@@ -1570,18 +1570,19 @@ static volatile int create_drive_pos;
 static int create_drive_raw(void* data)
 {
         int c;
+        int c_max = hd_new_cyl * hd_new_hpc * hd_new_spt;
         uint8_t buf[512];
         FILE* f = (FILE*)data;
 
         #ifdef __linux__
-          if((fallocate(fileno(f), FALLOC_FL_ZERO_RANGE, 0, (off64_t) (hd_new_cyl * hd_new_hpc * hd_new_spt) * 512)) == 0) {
-            create_drive_pos = (hd_new_cyl * hd_new_hpc * hd_new_spt);
+          if((fallocate(fileno(f), FALLOC_FL_ZERO_RANGE, 0, (off64_t) c_max * 512)) == 0) {
+            create_drive_pos = c_max;
             return 1;
           }
         #endif
 
         memset(buf, 0, 512);
-        for (c = 0; c < (hd_new_cyl * hd_new_hpc * hd_new_spt); c++)
+        for (c = 0; c < c_max; c++)
         {
                 create_drive_pos = c;
                 fwrite(buf, 512, 1, f);

--- a/src/wx-config.c
+++ b/src/wx-config.c
@@ -1,5 +1,7 @@
-// Enable glibc extensions
-#define _GNU_SOURCE
+#ifdef __linux__
+  #define _GNU_SOURCE
+  #include <linux/falloc.h>
+#endif
 
 #include "wx-utils.h"
 #include "wx-sdl2.h"
@@ -1572,7 +1574,7 @@ static int create_drive_raw(void* data)
         FILE* f = (FILE*)data;
 
         #ifdef __linux__
-          if(fallocate(fdopen(f, "w+"), FALLOC_FL_ZERO_RANGE, 0, (hd_new_cyl * hd_new_hpc * hd_new_spt)) == 0) {
+          if((fallocate(fileno(f), FALLOC_FL_ZERO_RANGE, 0, (hd_new_cyl * hd_new_hpc * hd_new_spt))) == 0) {
             create_drive_pos = (hd_new_cyl * hd_new_hpc * hd_new_spt);
             return 1;
           }

--- a/src/wx-config.c
+++ b/src/wx-config.c
@@ -1567,6 +1567,14 @@ static int create_drive_raw(void* data)
         int c;
         uint8_t buf[512];
         FILE* f = (FILE*)data;
+
+        #ifdef __linux__
+          if(fallocate(fdopen(f), FALLOC_FL_ZERO_RANGE, 0, (hd_new_cyl * hd_new_hpc * hd_new_spt) ) == 0)) {
+            create_drive_pos = (hd_new_cyl * hd_new_hpc * hd_new_spt);
+            return 1;
+          }
+        #endif
+
         memset(buf, 0, 512);
         for (c = 0; c < (hd_new_cyl * hd_new_hpc * hd_new_spt); c++)
         {

--- a/src/wx-config.c
+++ b/src/wx-config.c
@@ -1575,7 +1575,7 @@ static int create_drive_raw(void* data)
         FILE* f = (FILE*)data;
 
         #ifdef __linux__
-          if((fallocate(fileno(f), FALLOC_FL_ZERO_RANGE, 0, (off64_t) c_max * 512)) == 0) {
+          if((fallocate64(fileno(f), FALLOC_FL_ZERO_RANGE, 0, c_max * 512)) == 0) {
             create_drive_pos = c_max;
             return 1;
           }


### PR DESCRIPTION
There is a need for a better places to include the linux specific header.