### PR TITLE
Fix window corruption with Matrox Millennium when using 9-30-1998 Win9x driver

### DIFF
--- a/src/video/vid_mga.c
+++ b/src/video/vid_mga.c
@@ -2212,6 +2212,45 @@ static void mystique_accel_ctrl_write_l(uint32_t addr, uint32_t val, void* p)
         case REG_DWGCTL:
 //                pclog("  dwgctrl write %08x %08x\n", addr2, val);
                 mystique->dwgreg.dwgctrl = val;
+
+                if (val & DWGCTRL_SOLID)
+                {
+                        int x, y;
+
+                        for (y = 0; y < 8; y++)
+                        {
+                                for (x = 0; x < 8; x++)
+                                        mystique->dwgreg.pattern[y][x] = 1;
+                        }
+                        mystique->dwgreg.src[0] = 0xffffffff;
+                        mystique->dwgreg.src[1] = 0xffffffff;
+                        mystique->dwgreg.src[2] = 0xffffffff;
+                        mystique->dwgreg.src[3] = 0xffffffff;
+                }
+                if (val & DWGCTRL_ARZERO)
+                {
+                        mystique->dwgreg.ar[0] = 0;
+                        mystique->dwgreg.ar[1] = 0;
+                        mystique->dwgreg.ar[2] = 0;
+                        mystique->dwgreg.ar[4] = 0;
+                        mystique->dwgreg.ar[5] = 0;
+                        mystique->dwgreg.ar[6] = 0;
+                }
+                if (val & DWGCTRL_SGNZERO)
+                {
+                        mystique->dwgreg.sgn.sdydxl = 0;
+                        mystique->dwgreg.sgn.scanleft = 0;
+                        mystique->dwgreg.sgn.sdxl = 0;
+                        mystique->dwgreg.sgn.sdy = 0;
+                        mystique->dwgreg.sgn.sdxr = 0;
+                }
+                if (val & DWGCTRL_SHTZERO)
+                {
+                        mystique->dwgreg.funcnt = 0;
+                        mystique->dwgreg.stylelen = 0;
+                        mystique->dwgreg.xoff = 0;
+                        mystique->dwgreg.yoff = 0;
+                }
                 break;
 
         case REG_ZORG:
@@ -5544,44 +5583,6 @@ static void mystique_start_blit(mystique_t* mystique)
         if (mystique->busy)
                 fatal("mystique_start_blit: mystique->busy!\n");
 #endif
-        if (mystique->dwgreg.dwgctrl_running & DWGCTRL_SOLID)
-        {
-                int x, y;
-
-                for (y = 0; y < 8; y++)
-                {
-                        for (x = 0; x < 8; x++)
-                                mystique->dwgreg.pattern[y][x] = 1;
-                }
-                mystique->dwgreg.src[0] = 0xffffffff;
-                mystique->dwgreg.src[1] = 0xffffffff;
-                mystique->dwgreg.src[2] = 0xffffffff;
-                mystique->dwgreg.src[3] = 0xffffffff;
-        }
-        if (mystique->dwgreg.dwgctrl_running & DWGCTRL_ARZERO)
-        {
-                mystique->dwgreg.ar[0] = 0;
-                mystique->dwgreg.ar[1] = 0;
-                mystique->dwgreg.ar[2] = 0;
-                mystique->dwgreg.ar[4] = 0;
-                mystique->dwgreg.ar[5] = 0;
-                mystique->dwgreg.ar[6] = 0;
-        }
-        if (mystique->dwgreg.dwgctrl_running & DWGCTRL_SGNZERO)
-        {
-                mystique->dwgreg.sgn.sdydxl = 0;
-                mystique->dwgreg.sgn.scanleft = 0;
-                mystique->dwgreg.sgn.sdxl = 0;
-                mystique->dwgreg.sgn.sdy = 0;
-                mystique->dwgreg.sgn.sdxr = 0;
-        }
-        if (mystique->dwgreg.dwgctrl_running & DWGCTRL_SHTZERO)
-        {
-                mystique->dwgreg.funcnt = 0;
-                mystique->dwgreg.stylelen = 0;
-                mystique->dwgreg.xoff = 0;
-                mystique->dwgreg.yoff = 0;
-        }
 
         switch (mystique->dwgreg.dwgctrl_running & DWGCTRL_OPCODE_MASK)
         {


### PR DESCRIPTION
The Developer Specification for the MGA 1064SG (Matrox Millennium) states for the
SGNZERO bit of DWGCTRL that "Writing to the SGN register when sgnzero = 1 will
produce unpredictable results". However the 9-30-1998 Win9x driver will do exactly
this when programming FBITBLT commands. To accommodate this, handling of SGNZERO and
the other *ZERO bits have been moved to take effect immediately on writing to
DWGCTRL rather than when a blit actually starts.

This fixes corruption when moving windows in 32 bpp mode on the 9-30-1998 driver.