### PR TITLE
Enable compilation on macOS with Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,8 @@ include_directories(${SDL2_INCLUDE_DIRS})
 find_package(OpenAL REQUIRED)
 include_directories(${OPENAL_INCLUDE_DIR})
 
+include(apple.cmake)
+
 if(WIN32)
         set(wxWidgets_CONFIGURATION mswu)
 endif()
@@ -110,3 +112,4 @@ add_subdirectory(src)
 if(USE_EXPERIMENTAL)
         add_subdirectory(experimental)
 endif()
+

--- a/apple.cmake
+++ b/apple.cmake
@@ -1,0 +1,9 @@
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  get_filename_component(SDL2_INCLUDE_PARENT_DIR ${SDL2_INCLUDE_DIRS} DIRECTORY)
+  include_directories(${SDL2_INCLUDE_DIRS} ${SDL2_INCLUDE_PARENT_DIR})
+  add_compile_definitions(HAVE_UNISTD_H)
+
+  add_compile_definitions(fseeko64=fseeko off64_t=off_t fopen64=fopen ftello64=ftell)
+endif()
+

--- a/src/cdrom/cdrom.cmake
+++ b/src/cdrom/cdrom.cmake
@@ -20,3 +20,10 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
                 cdrom/cdrom-ioctl.c
                 )
 endif()
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+        set(PCEM_SRC ${PCEM_SRC} ${PCEM_SRC_CDROM}
+                cdrom/cdrom-ioctl-osx.c
+                )
+endif()
+

--- a/src/plugin-api/logging.c
+++ b/src/plugin-api/logging.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <errno.h>
 
 #include "config.h"
 #include "paths.h"
@@ -26,6 +27,11 @@ void error(const char* format, ...)
                 put_backslash(buf);
                 strcat(buf, "pcem.log");
                 pclogf = fopen(buf, "wt");
+
+                if (NULL == pclogf) {
+                  fprintf(stderr, "Could not open log file for writing: %s",  strerror(errno));
+                  return;
+                }
         }
         //return;
         va_list ap;
@@ -49,6 +55,12 @@ void fatal(const char* format, ...)
                 put_backslash(buf);
                 strcat(buf, "pcem.log");
                 pclogf = fopen(buf, "wt");
+
+                if (NULL == pclogf) {
+                  fprintf(stderr, "Could not open log file for writing: %s",  strerror(errno));
+                  return;
+                }
+
         }
         //return;
         va_list ap;
@@ -89,6 +101,11 @@ void pclog(const char* format, ...)
                 put_backslash(buf);
                 strcat(buf, "pcem.log");
                 pclogf = fopen(buf, "wt");
+                if (NULL == pclogf) {
+                  fprintf(stderr, "Could not open log file for writing: %s",  strerror(errno));
+                  return;
+                }
+
         }
         //return;
         va_list ap;

--- a/src/plugin-api/paths.c
+++ b/src/plugin-api/paths.c
@@ -2,6 +2,7 @@
 #include "config.h"
 #include <string.h>
 #include <SDL.h>
+#include <sys/stat.h>
 #include "ibm.h"
 #include "wx-utils.h"
 

--- a/src/wx-ui/wx-ui.cmake
+++ b/src/wx-ui/wx-ui.cmake
@@ -73,3 +73,13 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
                 wx-ui/wx.rc
                 )
 endif()
+
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+	set(PCEM_SRC ${PCEM_SRC}
+		wx-ui/wx-sdl2-display.c
+	)
+
+  add_compile_definitions(PCEM_RENDER_WITH_TIMER PCEM_RENDER_TIMER_LOOP)
+
+endif()


### PR DESCRIPTION
I added several definitions and to be able to enable compilation in macOS Monterey.

- Define `HAVE_UNISTD_H` for SLIRP to be able to compile.
- Add `sys/stat.h` (standard POSIX header) 
- Redefine `fseeko64` `ftello64` `off64_t` to normal `fseeko` `ftello` and `off_t` as recent macs only supports 64-bit platforms.
- Re-include `cdrom/cdrom-ioctl-osx.c` on macOS
- Define `PCEM_RENDER_WITH_TIMER` and `PCEM_RENDER_TIMER_LOOP` because macos cannot render outside main thread on SDL.

**Known Issues**

- Using -O0 optimisation on `src/cpu/386_dynarec.c` doesn't seem to work on Clang. (crashes on release build)

**EDIT**

Added one more commit for fixing error handling on logging.