### PR TITLE
Fix for Issue #139 : Mouse didn't move on Windows host.

### DIFF
--- a/src/wx-ui/wx-sdl2-display-win.c
+++ b/src/wx-ui/wx-sdl2-display-win.c
@@ -772,14 +772,12 @@ int render() {
 	if (window_doinputgrab) {
 		window_doinputgrab = 0;
 		mousecapture = 1;
-		SDL_GetRelativeMouseState(0, 0);
-		SDL_SetWindowGrab(window, SDL_TRUE);
-		SDL_SetRelativeMouseMode(SDL_TRUE);
-	}
-	if (mousecapture) {
 		SDL_Rect rect;
 		SDL_GetWindowSize(window, &rect.w, &rect.h);
 		SDL_WarpMouseInWindow(window, rect.w / 2, rect.h / 2);
+		SDL_SetWindowGrab(window, SDL_TRUE);
+		SDL_SetRelativeMouseMode(SDL_TRUE);
+		SDL_GetRelativeMouseState(0, 0);
 	}
 
 	if (window_doinputrelease) {


### PR DESCRIPTION
This solves the issue #139 where it was detected that mouse stopped moving on windows Hosts.

Original code was centering the (host) mouse on PCem screen at each screen redraw so that moving it would never reach the Host screen borders.

This is a non-issue since SDL is providing relative mouse movements to PCem, and is not being affected by the absolute host mouse position, and current (SDL) version is triggering a mouse move event, so the final effect was to return the guest mouse to the initial position.