### PR TITLE
Logging improvements.

### DIFF
--- a/includes/private/logging-internal.h
+++ b/includes/private/logging-internal.h
@@ -1,0 +1,17 @@
+#ifndef __PCEM_LOGGING_INTERNAL_H__
+#define __PCEM_LOGGING_INTERNAL_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Used to flush the log contents to disk.
+void pclog_flush();
+// Used to close the file handle and flush the last contents to disk. Only use it when closing the application
+void pclog_end();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __PCEM_LOGGING_INTERNAL_H__ */

--- a/src/cpu/x86seg.c
+++ b/src/cpu/x86seg.c
@@ -11,6 +11,7 @@
 #include "config.h"
 #include "paths.h"
 #include "i440bx.h"
+#include "logging-internal.h"
 
 /*Controls whether the accessed bit in a descriptor is set when CS is loaded.*/
 #define CS_ACCESSED
@@ -36,24 +37,13 @@ void taskswitch386(uint16_t seg, uint16_t *segdat);
 /*NOT PRESENT is INT 0B
   GPF is INT 0D*/
 
-FILE *pclogf;
 void x86abort(const char *format, ...) {
-	char buf[256];
-	//   return;
-	if (!pclogf) {
-		strcpy(buf, logs_path);
-		put_backslash(buf);
-		strcat(buf, "pcem.log");
-		pclogf = fopen(buf, "wt");
-	}
-	//return;
 	va_list ap;
 	va_start(ap, format);
-	vsprintf(buf, format, ap);
+	error(format, ap);
 	va_end(ap);
-	fputs(buf, pclogf);
-	fflush(pclogf);
 	dumpregs();
+	pclog_end();
 	exit(-1);
 }
 

--- a/src/wx-ui/wx-app.cc
+++ b/src/wx-ui/wx-app.cc
@@ -4,6 +4,7 @@
 #include <wx/event.h>
 #include "wx-utils.h"
 #include "wx-common.h"
+#include "logging-internal.h"
 
 #ifdef _WIN32
 #define BITMAP WINDOWS_BITMAP
@@ -119,7 +120,7 @@ void Frame::OnStopEmulationEvent(wxCommandEvent &event) {
 	if (emulation_state != EMULATION_STOPPED) {
 		pause_emulation();
 		int ret = wxID_OK;
-
+		pclog_flush();
 		if (confirm_on_stop_emulation) {
 			wxDialog dlg;
 			wxXmlResource::Get()->LoadDialog(&dlg, this, "ConfirmRememberDlg");
@@ -144,6 +145,7 @@ void Frame::OnStopEmulationEvent(wxCommandEvent &event) {
 
 void Frame::OnStopEmulationNowEvent(wxCommandEvent &event) {
 	stop_emulation();
+	pclog_flush();
 	if (!config_override)
 		ShowConfigSelection();
 	else
@@ -179,6 +181,7 @@ void Frame::OnCommand(wxCommandEvent &event) {
 }
 
 void Frame::OnClose(wxCloseEvent &event) {
+	pclog_end();
 	wx_exit(this, 0);
 }
 
@@ -199,6 +202,7 @@ void Frame::Quit(bool stop_emulator) {
 			return;
 		}
 	}
+	pclog_end();
 	Destroy();
 }
 
@@ -211,8 +215,10 @@ void Frame::OnExitEvent(wxCommandEvent &event) {
 }
 
 void Frame::OnExitCompleteEvent(wxCommandEvent &event) {
-	if (event.GetInt())
+	if (event.GetInt()) {
+		pclog_end();
 		Destroy();
+	}
 	else
 		closing = false;
 }


### PR DESCRIPTION
Since we don't flush the messages to file immediately to avoid slowdowns, sometimes the application is closed before all the messages are written to the log.
This includes flushing the log when stopping the emulation, and tries to close the log file when closing the application. (It might need some more work to close it in all cases).
Also, some redundancy in logging.c and x86seg.c has been removed.