### PR TITLE
Fixes on window positioning on Windows.

### DIFF
--- a/src/wx-ui/wx-sdl2.c
+++ b/src/wx-ui/wx-sdl2.c
@@ -128,6 +128,9 @@ int screenshot_flash = 1;
 int take_screenshot = 0;
 
 void updatewindowsize(int x, int y) {
+	if (video_width == x && video_height == y) {
+		return;
+	}
 	video_width = x;
 	video_height = y;
 


### PR DESCRIPTION
On Windows, the emulator window has a menu bar. This menu is hidden and shown when closing the emulation and when toggling fullscreen.
It was found that doing so before getting the window position gave an incorrect value so when restoring the window, the top position was shifted up.
Also, all the code about substracting the window borders seem unneeded for current SDL, or at least it also implied an unneeded offset.
Also fixed the option to open the emulation window centered on screen. It needs to know the window size before telling it to center it on screen.
Also found that, at least with SVGA, window_resize was called each render call. This means that the win_doresize was also being called, if using the "original" resize mode or the fullscreen mode.
This has been prevented if the size hasn't changed, and only forced when changing scaling.

Part of this solves Issue #47 