### PR TITLE
src/cpu/386_dynarec.c: use noinline for exec_recompiler

### DIFF
--- a/src/cpu/386_dynarec.c
+++ b/src/cpu/386_dynarec.c
@@ -260,7 +260,7 @@ static inline void exec_interpreter(void) {
  *       a SEGFAULT
  */
 
-static inline void exec_recompiler(void) {
+static void __attribute__((noinline)) exec_recompiler(void) {
 	uint32_t phys_addr = get_phys(cs + cpu_state.pc);
 	int hash = HASH(phys_addr);
 	codeblock_t *block = &codeblock[codeblock_hash[hash]];


### PR DESCRIPTION
From issue #157; allows the dynamic recompiler to run when compiled with GCC 11.2 at -O2 or -O3.

Like I said in the issue comment thread, I haven't been able to check for a performance hit for GCC 10.x, so no hard feelings if the patch can't be accepted. Thank you!