### PR TITLE
Reduce filter gain value to 0.65 on AudioPCI-based cards

### DIFF
--- a/src/sound/sound_audiopci.c
+++ b/src/sound/sound_audiopci.c
@@ -1212,7 +1212,7 @@ static void generate_es1371_filter() {
         for (n = 0; n < ES1371_NCoef; n++)
                 gain += low_fir_es1371_coef[n] / (float)N;
 
-        gain /= 0.95;
+        gain /= 0.65;
 
         /*Normalise filter, to produce unity gain*/
         for (n = 0; n < ES1371_NCoef; n++)


### PR DESCRIPTION
Fixes crackling, popping and distorted sounds in a number of games,  DOS ones in particularly.