### PR TITLE
Get rid of VLAs.

### DIFF
--- a/includes/private/sound/sound.h
+++ b/includes/private/sound/sound.h
@@ -36,7 +36,7 @@ void sound_update_buf_length();
 
 extern int sound_gain;
 
-extern int SOUNDBUFLEN;
+extern int sound_buf_len_al;
 #define MAXSOUNDBUFLEN (48000 / 10)
 
 #endif /* _SOUND_H_ */

--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -128,7 +128,7 @@ void sound_update_buf_length() {
         if (new_buf_len > MAXSOUNDBUFLEN)
                 new_buf_len = MAXSOUNDBUFLEN;
 
-        SOUNDBUFLEN = new_buf_len;
+        sound_buf_len_al = new_buf_len;
 }
 
 void sound_set_cd_volume(unsigned int vol_l, unsigned int vol_r) {
@@ -221,16 +221,16 @@ void sound_poll(void *priv) {
         }
 
         sound_pos_global++;
-        if (sound_pos_global == SOUNDBUFLEN) {
+        if (sound_pos_global == sound_buf_len_al) {
                 int c;
-                /*                int16_t buf16[SOUNDBUFLEN * 2 ];*/
+                /*                int16_t buf16[sound_buf_len_al * 2 ];*/
 
-                memset(outbuffer, 0, SOUNDBUFLEN * 2 * sizeof(int32_t));
+                memset(outbuffer, 0, sound_buf_len_al * 2 * sizeof(int32_t));
 
                 for (c = 0; c < sound_handlers_num; c++)
-                        sound_handlers[c].get_buffer(outbuffer, SOUNDBUFLEN, sound_handlers[c].priv);
+                        sound_handlers[c].get_buffer(outbuffer, sound_buf_len_al, sound_handlers[c].priv);
 
-                /*                for (c=0;c<SOUNDBUFLEN*2;c++)
+                /*                for (c=0;c<sound_buf_len_al*2;c++)
                                 {
                                         if (outbuffer[c] < -32768)
                                                 buf16[c] = -32768;
@@ -241,7 +241,7 @@ void sound_poll(void *priv) {
                                 }
 
                         if (!soundf) soundf=fopen("sound.pcm","wb");
-                        fwrite(buf16,(SOUNDBUFLEN)*2*2,1,soundf);*/
+                        fwrite(buf16,(sound_buf_len_al)*2*2,1,soundf);*/
 
                 if (soundon)
                         givealbuffer(outbuffer);

--- a/src/sound/sound_adlibgold.c
+++ b/src/sound/sound_adlibgold.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include "ibm.h"
@@ -629,9 +630,10 @@ void adgold_timer_poll(void *p) {
 
 static void adgold_get_buffer(int32_t *buffer, int len, void *p) {
         adgold_t *adgold = (adgold_t *)p;
-        int16_t adgold_buffer[len * 2];
-
+        int16_t adgold_buffer[MAXSOUNDBUFLEN * 2];
         int c;
+
+        assert(len <= MAXSOUNDBUFLEN);
 
         opl3_update2(&adgold->opl);
         adgold_update(adgold);

--- a/src/sound/soundopenal.c
+++ b/src/sound/soundopenal.c
@@ -23,9 +23,9 @@ static ALuint source[2]; // audio source
 #endif
 #define FREQ 48000
 
-int SOUNDBUFLEN = 48000 / 20;
+int sound_buf_len_al = 48000 / 20;
 
-#define BUFLEN SOUNDBUFLEN
+#define BUFLEN sound_buf_len_al
 
 void closeal();
 ALvoid alutInit(ALint *argc, ALbyte **argv) {

--- a/src/sound/soundopenal.c
+++ b/src/sound/soundopenal.c
@@ -1,4 +1,5 @@
 #define USE_OPENAL
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -85,8 +86,10 @@ void check() {
 void inital() {
 #ifdef USE_OPENAL
         int c;
-        int16_t buf[sound_buf_len_al * 2];
+        int16_t buf[MAXSOUNDBUFLEN * 2];
         int16_t cd_buf[CD_BUFLEN * 2];
+
+        assert(sound_buf_len_al <= MAXSOUNDBUFLEN);
 
         //        printf("1\n");
         check();
@@ -139,9 +142,11 @@ void inital() {
 
 void givealbuffer(int32_t *buf) {
 #ifdef USE_OPENAL
-        int16_t buf16[sound_buf_len_al * 2];
+        int16_t buf16[MAXSOUNDBUFLEN * 2];
         int processed;
         int state;
+
+        assert(sound_buf_len_al <= MAXSOUNDBUFLEN);
 
         // return;
 

--- a/src/sound/soundopenal.c
+++ b/src/sound/soundopenal.c
@@ -25,8 +25,6 @@ static ALuint source[2]; // audio source
 
 int sound_buf_len_al = 48000 / 20;
 
-#define BUFLEN sound_buf_len_al
-
 void closeal();
 ALvoid alutInit(ALint *argc, ALbyte **argv) {
         ALCcontext *Context;
@@ -87,7 +85,7 @@ void check() {
 void inital() {
 #ifdef USE_OPENAL
         int c;
-        int16_t buf[BUFLEN * 2];
+        int16_t buf[sound_buf_len_al * 2];
         int16_t cd_buf[CD_BUFLEN * 2];
 
         //        printf("1\n");
@@ -117,12 +115,12 @@ void inital() {
         alSourcei(source[1], AL_SOURCE_RELATIVE, AL_TRUE);
         check();
 
-        memset(buf, 0, BUFLEN * 4);
+        memset(buf, 0, sound_buf_len_al * 4);
         memset(cd_buf, 0, CD_BUFLEN * 4);
 
         //        printf("5\n");
         for (c = 0; c < 4; c++) {
-                alBufferData(buffers[c], AL_FORMAT_STEREO16, buf, BUFLEN * 2 * 2, FREQ);
+                alBufferData(buffers[c], AL_FORMAT_STEREO16, buf, sound_buf_len_al * 2 * 2, FREQ);
                 alBufferData(buffers_cd[c], AL_FORMAT_STEREO16, cd_buf, CD_BUFLEN * 2 * 2, CD_FREQ);
         }
 
@@ -141,7 +139,7 @@ void inital() {
 
 void givealbuffer(int32_t *buf) {
 #ifdef USE_OPENAL
-        int16_t buf16[BUFLEN * 2];
+        int16_t buf16[sound_buf_len_al * 2];
         int processed;
         int state;
 
@@ -178,7 +176,7 @@ void givealbuffer(int32_t *buf) {
                 //                printf("U ");
                 check();
 
-                for (c = 0; c < BUFLEN * 2; c++) {
+                for (c = 0; c < sound_buf_len_al * 2; c++) {
                         if (buf[c] < -32768)
                                 buf16[c] = -32768;
                         else if (buf[c] > 32767)
@@ -186,8 +184,8 @@ void givealbuffer(int32_t *buf) {
                         else
                                 buf16[c] = buf[c];
                 }
-                //                for (c=0;c<BUFLEN*2;c++) buf[c]^=0x8000;
-                alBufferData(buffer, AL_FORMAT_STEREO16, buf16, BUFLEN * 2 * 2, FREQ);
+                //                for (c=0;c<sound_buf_len_al*2;c++) buf[c]^=0x8000;
+                alBufferData(buffer, AL_FORMAT_STEREO16, buf16, sound_buf_len_al * 2 * 2, FREQ);
                 //                printf("B ");
                 check();
 
@@ -198,7 +196,7 @@ void givealbuffer(int32_t *buf) {
                 //                printf("\n");
 
                 //                if (!allog) allog=fopen("al.pcm","wb");
-                //                fwrite(buf,BUFLEN*2,1,allog);
+                //                fwrite(buf,sound_buf_len_al*2,1,allog);
         }
 //        printf("\n");
 #endif
@@ -241,7 +239,7 @@ void givealbuffer_cd(int16_t *buf) {
                 //                printf("U ");
                 check();
 
-                //                for (c=0;c<BUFLEN*2;c++) buf[c]^=0x8000;
+                //                for (c=0;c<sound_buf_len_al*2;c++) buf[c]^=0x8000;
                 alBufferData(buffer, AL_FORMAT_STEREO16, buf, CD_BUFLEN * 2 * 2, CD_FREQ);
                 //                printf("B ");
                 check();
@@ -253,7 +251,7 @@ void givealbuffer_cd(int16_t *buf) {
                 //                printf("\n");
 
                 //                if (!allog) allog=fopen("al.pcm","wb");
-                //                fwrite(buf,BUFLEN*2,1,allog);
+                //                fwrite(buf,sound_buf_len_al*2,1,allog);
         }
 //        printf("\n");
 #endif

--- a/src/video/vid_voodoo_banshee.c
+++ b/src/video/vid_voodoo_banshee.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdlib.h>
 #include "ibm.h"
 #include "device.h"
@@ -2073,9 +2074,10 @@ static void banshee_overlay_draw(svga_t *svga, int displine) {
 
                 case VIDPROCCFG_FILTER_MODE_DITHER_4X4:
                         if (banshee->voodoo->scrfilter && banshee->voodoo->scrfilterEnabled) {
-                                uint8_t fil[(svga->overlay_latch.xsize) * 3];
-                                uint8_t fil3[(svga->overlay_latch.xsize) * 3];
+                                uint8_t fil[64 * 3];
+                                uint8_t fil3[64 * 3];
 
+                                assert(svga->overlay_latch.xsize <= 64);
                                 if (banshee->vidProcCfg & VIDPROCCFG_H_SCALE_ENABLE) /* leilei HACK - don't know of real 4x1
                                                                                         hscaled behavior yet, double for now */
                                 {
@@ -2143,15 +2145,16 @@ static void banshee_overlay_draw(svga_t *svga, int displine) {
 
                 case VIDPROCCFG_FILTER_MODE_DITHER_2X2:
                         if (banshee->voodoo->scrfilter && banshee->voodoo->scrfilterEnabled) {
-                                uint8_t fil[(svga->overlay_latch.xsize) * 3];
-                                uint8_t soak[(svga->overlay_latch.xsize) * 3];
-                                uint8_t soak2[(svga->overlay_latch.xsize) * 3];
+                                uint8_t fil[64 * 3];
+                                uint8_t soak[64 * 3];
+                                uint8_t soak2[64 * 3];
 
-                                uint8_t samp1[(svga->overlay_latch.xsize) * 3];
-                                uint8_t samp2[(svga->overlay_latch.xsize) * 3];
-                                uint8_t samp3[(svga->overlay_latch.xsize) * 3];
-                                uint8_t samp4[(svga->overlay_latch.xsize) * 3];
+                                uint8_t samp1[64 * 3];
+                                uint8_t samp2[64 * 3];
+                                uint8_t samp3[64 * 3];
+                                uint8_t samp4[64 * 3];
 
+                                assert(svga->overlay_latch.xsize <= 64);
                                 src = &svga->vram[src_addr2 & svga->vram_mask];
                                 OVERLAY_SAMPLE(banshee->overlay_buffer[1]);
                                 for (x = 0; x < svga->overlay_latch.xsize; x++) {

--- a/src/video/vid_voodoo_display.c
+++ b/src/video/vid_voodoo_display.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include "ibm.h"
 #include "device.h"
 #include "mem.h"
@@ -317,7 +318,9 @@ static void voodoo_filterline_v1(voodoo_t *voodoo, uint8_t *fil, int column, uin
         int x;
 
         // Scratchpad for avoiding feedback streaks
-        uint8_t fil3[(voodoo->h_disp) * 3];
+        uint8_t fil3[4096 * 3];
+
+        assert(voodoo->h_disp <= 4096);
 
         /* 16 to 32-bit */
         for (x = 0; x < column; x++) {
@@ -372,7 +375,9 @@ static void voodoo_filterline_v2(voodoo_t *voodoo, uint8_t *fil, int column, uin
         int x;
 
         // Scratchpad for blending filter
-        uint8_t fil3[(voodoo->h_disp) * 3];
+        uint8_t fil3[4096 * 3];
+
+        assert(voodoo->h_disp <= 4096);
 
         /* 16 to 32-bit */
         for (x = 0; x < column; x++) {
@@ -469,7 +474,9 @@ void voodoo_callback(void *p) {
                                         voodoo->dirty_line_high = voodoo->line;
 
                                 if (voodoo->scrfilter && voodoo->scrfilterEnabled) {
-                                        uint8_t fil[(voodoo->h_disp) * 3]; /* interleaved 24-bit RGB */
+                                        uint8_t fil[4096 * 3]; /* interleaved 24-bit RGB */
+
+                                        assert(voodoo->h_disp <= 4096);
 
                                         if (voodoo->type == VOODOO_2)
                                                 voodoo_filterline_v2(voodoo, fil, voodoo->h_disp, src, voodoo->line);


### PR DESCRIPTION
Hi, VLAs (variable-lenght-arrays) in C language are evil, their size is computed at run-time (and they are most likely allocated by using alloca). In many cases we know the worst possible size the array will ever have at compile-time. It is better to compute size of such array at compile-time rather than at run-time. This is also step forward to be able to compile pcem by MSVC as it does not support VLAs.