### PR TITLE
Fix for Windows home directory with spaces and fixes also issue #207

### DIFF
--- a/src/plugin-api/wx-utils.cc
+++ b/src/plugin-api/wx-utils.cc
@@ -12,6 +12,20 @@ void wx_get_home_directory(char *path) {
         if (!home.EndsWith(wxFileName::GetPathSeparator())) {
                 home.Append(wxFileName::GetPathSeparator());
         }
+        #ifdef _WIN32
+        wxString str = home;
+        int i1, i2, len = str.length();
+        for (i1 = 0; i1 < len; i1++) {
+            if (str[i1] == '\"') {
+                for (i2 = i1; i2 < len - 1; i2++) {
+                    str[i2] = str[i2+1];
+                }
+                len--;
+                i1--;
+            }
+        }        
+        home = str;
+        #endif        
         strcpy(path, home.mb_str());
 }
 

--- a/src/video/vid_unk_ramdac.c
+++ b/src/video/vid_unk_ramdac.c
@@ -1,70 +1,94 @@
+/* Copyright holders: Sarah Walker, Tenshi
+   see COPYING for more details
+*/
 /*It is unknown exactly what RAMDAC this is
   It is possibly a Sierra 1502x
   It's addressed by the TLIVESA1 driver for ET4000*/
+/* Note by Tenshi: Not possibly, this *IS* a Sierra 1502x. */
 #include "ibm.h"
 #include "mem.h"
 #include "video.h"
 #include "vid_svga.h"
 #include "vid_unk_ramdac.h"
 
-void unk_ramdac_out(uint16_t addr, uint8_t val, unk_ramdac_t *ramdac, svga_t *svga) {
+void unk_ramdac_out(uint16_t addr, uint8_t val, unk_ramdac_t *ramdac, svga_t *svga)
+{
         // pclog("OUT RAMDAC %04X %02X\n",addr,val);
-        switch (addr) {
-        case 0x3C6:
-                if (ramdac->state == 4) {
+	int oldbpp = 0;
+        switch (addr)
+        {
+                case 0x3C6:
+                if (ramdac->state == 4)
+                {
                         ramdac->state = 0;
+			if (val == 0xFF)  break;
                         ramdac->ctrl = val;
-                        switch ((val & 1) | ((val & 0xE0) >> 4)) {
-                        case 0:
-                        case 1:
-                        case 2:
-                        case 3:
+			oldbpp = svga->bpp;
+                        switch ((val&1)|((val&0xC0)>>5))
+                        {
+                                case 0:
                                 svga->bpp = 8;
                                 break;
-                        case 6:
-                        case 7:
-                                svga->bpp = 24;
+                                case 2: case 3:
+				switch (val & 0x20)
+				{
+					case 0x00: svga->bpp = 32; break;
+	                                case 0x20: svga->bpp = 24; break;
+				}
                                 break;
-                        case 8:
-                        case 9:
-                        case 0xA:
-                        case 0xB:
+                                case 4: case 5:
                                 svga->bpp = 15;
                                 break;
-                        case 0xC:
-                        case 0xD:
-                        case 0xE:
-                        case 0xF:
+                                case 6:
                                 svga->bpp = 16;
                                 break;
+                                case 7:
+                                switch (val & 4)
+                                {
+                                        case 4:
+				                switch (val & 0x20)
+				                {
+					                case 0x00: svga->bpp = 32; break;
+	                                                case 0x20: svga->bpp = 24; break;
+				                }
+                                                break;
+                                        case 0: default:
+                                                svga->bpp = 16;
+                                                break;
+                                }
+				case 1: default:
+				break;
                         }
-                        svga_recalctimings(svga);
+			if (oldbpp != svga->bpp)
+			{
+				svga_recalctimings(svga);
+			}
+			// pclog("unk_ramdac: set to %02X (b5 = %i) [%02X], %i bpp\n", (val&1)|((val&0xC0)>>5), val & 0x20 ? 1 : 0, val, svga->bpp);
                         return;
                 }
                 ramdac->state = 0;
                 break;
-        case 0x3C7:
-        case 0x3C8:
-        case 0x3C9:
+                case 0x3C7: case 0x3C8: case 0x3C9:
                 ramdac->state = 0;
                 break;
         }
         svga_out(addr, val, svga);
 }
 
-uint8_t unk_ramdac_in(uint16_t addr, unk_ramdac_t *ramdac, svga_t *svga) {
+uint8_t unk_ramdac_in(uint16_t addr, unk_ramdac_t *ramdac, svga_t *svga)
+{
         // pclog("IN RAMDAC %04X\n",addr);
-        switch (addr) {
-        case 0x3C6:
-                if (ramdac->state == 4) {
+        switch (addr)
+        {
+                case 0x3C6:
+                if (ramdac->state == 4)
+                {
                         ramdac->state = 0;
                         return ramdac->ctrl;
                 }
                 ramdac->state++;
                 break;
-        case 0x3C7:
-        case 0x3C8:
-        case 0x3C9:
+                case 0x3C7: case 0x3C8: case 0x3C9:
                 ramdac->state = 0;
                 break;
         }


### PR DESCRIPTION
Update wx-utils.cc
Fix for Windows home directory with spaces

Update vid_unk_ramdac.c
Fixes ET4000AX (kasan16) hang in win95 in 16/24 bit modes https://github.com/sarah-walker-pcem/pcem/issues/207

It's just a copy of: https://github.com/86Box/86Box/blob/291ac890e2cfa355b81fe1d78697541172d6bbc1/src/vid_unk_ramdac.c

In 86box they later renamed it to vid_sc1502x_ramdac.c which makes sense knowing exactly what ramdac it is.