### PR TITLE
cmake: add detection logic for aarch64

### DIFF
--- a/cmake/arch-detect.cmake
+++ b/cmake/arch-detect.cmake
@@ -35,6 +35,8 @@ set(archdetect_c_code "
     #else
         #error cmake_ARCH ppc
     #endif
+#elif defined(__aarch64__) || defined(_M_ARM64)
+    #error cmake_ARCH arm64
 #endif
 
 #error cmake_ARCH unknown


### PR DESCRIPTION
This fixes https://github.com/sarah-walker-pcem/pcem/issues/102 and allows pcem to build successfully on aarch64 systems on Linux.