### PR TITLE
Switch from off64_t to off_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ endif()
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fomit-frame-pointer -mstackrealign -fno-strict-aliasing")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer -mstackrealign -fno-strict-aliasing")
 
+if (UNIX)
+	add_definitions(-D_FILE_OFFSET_BITS=64)
+endif ()
+
 set(PCEM_VERSION_STRING "vNext" CACHE STRING "PCem Version String")
 set(PCEM_DISPLAY_ENGINE "wxWidgets" CACHE STRING "PCem Display Engine")
 set(PCEM_DEFINES ${PCEM_DEFINES} PCEM_VERSION_STRING="${PCEM_VERSION_STRING}")

--- a/src/wx-ui/wx-config.c
+++ b/src/wx-ui/wx-config.c
@@ -1337,7 +1337,7 @@ static device_t *hdd_controller_selected_get_device(void *hdlg) {
         return NULL;
 }
 
-static void check_hd_type(void *hdlg, off64_t sz) {
+static void check_hd_type(void *hdlg, off_t sz) {
         int c;
 
         hd_new_type = 0;
@@ -2037,7 +2037,7 @@ static int hd_new(void *hdlg, int drive) {
 
 static int hd_file(void *hdlg, int drive) {
         if (!getfile(hdlg, "Hard disc image (*.img;*.vhd)|*.img;*.vhd|All files (*.*)|*.*", "")) {
-                off64_t sz;
+                off_t sz;
                 FILE *f = fopen64(openfilestring, "rb");
                 if (!f) {
                         wx_messagebox(hdlg, "Can't open file for read", "PCem error", WX_MB_OK);


### PR DESCRIPTION
This fixed compilation with musl, as usage of off64_t is deprecated and instead 'FILE_OFFSET_BITS=64' should be set.