### PR TITLE
Avoid segmentation fault loading config file with Windows \r\n line endings

### DIFF
--- a/src/plugin-api/config.c
+++ b/src/plugin-api/config.c
@@ -199,7 +199,7 @@ void config_load(int is_global, char *fn) {
 
                         data_pos = c;
                         while (buffer[c]) {
-                                if (buffer[c] == '\n')
+                                if (buffer[c] == '\n' || buffer[c] == '\r')
                                         buffer[c] = 0;
                                 c++;
                         }


### PR DESCRIPTION
The problem doesn't seem to occur in Windows, only in Linux (and presumably *nix in general) when trying to load a config file that was created (and perhaps hand-edited) in Windows.