### PR TITLE
Fix sound config button. 

### DIFF
--- a/src/sound/sound.c
+++ b/src/sound/sound.c
@@ -73,7 +73,7 @@ device_t *sound_card_getdevice(int card) {
 }
 
 int sound_card_has_config(int card) {
-        if (sound_cards[card] != NULL || !sound_cards[card]->device)
+        if (sound_cards[card] == NULL || sound_cards[card]->device == NULL)
                 return 0;
         return sound_cards[card]->device->config ? 1 : 0;
 }


### PR DESCRIPTION
The button on sound configuration to configure soundcard specific settings was always disabled.

Fixes Issue #235