### PR TITLE
changes to compile again with networking enabled.

### DIFF
--- a/.github/workflows/test-debug-builds.yml
+++ b/.github/workflows/test-debug-builds.yml
@@ -14,7 +14,7 @@ jobs:
                 include:
                     - name: Ubuntu 64bit (gcc)
                       os: ubuntu-latest
-                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=OFF -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=Debug -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
+                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=ON -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=Debug -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
                       artifacts_name: PCem-Debug-vNext-Ubuntu-${{ github.run_number }}
                       artifacts_path: PCem-Debug-vNext-Ubuntu-${{ github.run_number }}-${{ github.sha }}.tar.bz2
                       installdeps: >-
@@ -27,7 +27,7 @@ jobs:
                     - name: Windows 32bits (MSYS2)
                       os: windows-latest
                       compiler: MINGW32
-                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=OFF -DUSE_PCAP_NETWORKING=OFF -DCMAKE_BUILD_TYPE=Debug -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
+                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=ON -DUSE_PCAP_NETWORKING=OFF -DCMAKE_BUILD_TYPE=Debug -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
                       artifacts_name: PCem-Debug-vNext-Windows-MINGW32-${{ github.run_number }}
                       artifacts_path: PCem-Debug-vNext-Windows-MINGW32-${{ github.run_number }}-${{ github.sha }}.zip
                       installdeps: >-
@@ -44,7 +44,7 @@ jobs:
                     - name: Windows 64bits (MSYS2)
                       os: windows-latest
                       compiler: MINGW64
-                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=OFF -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=Debug -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
+                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=ON -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=Debug -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
                       artifacts_name: PCem-Debug-vNext-Windows-MINGW64-${{ github.run_number }}
                       artifacts_path: PCem-Debug-vNext-Windows-MINGW64-${{ github.run_number }}-${{ github.sha }}.zip
                       installdeps: >-

--- a/.github/workflows/test-release-builds.yml
+++ b/.github/workflows/test-release-builds.yml
@@ -14,7 +14,7 @@ jobs:
                 include:
                     - name: Ubuntu 64bit (gcc)
                       os: ubuntu-latest
-                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=OFF -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=Release -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
+                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=ON -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=Release -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
                       artifacts_name: PCem-vNext-Ubuntu-${{ github.run_number }}
                       artifacts_path: PCem-vNext-Ubuntu-${{ github.run_number }}-${{ github.sha }}.tar.bz2
                       installdeps: >-
@@ -27,7 +27,7 @@ jobs:
                     - name: Windows 32bits (MSYS2)
                       os: windows-latest
                       compiler: MINGW32
-                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=OFF -DUSE_PCAP_NETWORKING=OFF -DCMAKE_BUILD_TYPE=Release -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
+                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=ON -DUSE_PCAP_NETWORKING=OFF -DCMAKE_BUILD_TYPE=Release -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
                       artifacts_name: PCem-vNext-Windows-MINGW32-${{ github.run_number }}
                       artifacts_path: PCem-vNext-Windows-MINGW32-${{ github.run_number }}-${{ github.sha }}.zip
                       installdeps: >-
@@ -44,7 +44,7 @@ jobs:
                     - name: Windows 64bits (MSYS2)
                       os: windows-latest
                       compiler: MINGW64
-                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=OFF -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=Release -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
+                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=ON -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=Release -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
                       artifacts_name: PCem-vNext-Windows-MINGW64-${{ github.run_number }}
                       artifacts_path: PCem-vNext-Windows-MINGW64-${{ github.run_number }}-${{ github.sha }}.zip
                       installdeps: >-

--- a/.github/workflows/test-relwithdebinfo-builds.yml
+++ b/.github/workflows/test-relwithdebinfo-builds.yml
@@ -14,7 +14,7 @@ jobs:
                 include:
                     - name: Ubuntu 64bit (gcc)
                       os: ubuntu-latest
-                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=OFF -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPCEM_RELDEB_AS_RELEASE=OFF -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
+                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=ON -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPCEM_RELDEB_AS_RELEASE=OFF -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
                       artifacts_name: PCem-RelWithDebInfo-vNext-Ubuntu-${{ github.run_number }}
                       artifacts_path: PCem-RelWithDebInfo-vNext-Ubuntu-${{ github.run_number }}-${{ github.sha }}.tar.bz2
                       installdeps: >-
@@ -27,7 +27,7 @@ jobs:
                     - name: Windows 32bits (MSYS2)
                       os: windows-latest
                       compiler: MINGW32
-                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=OFF -DUSE_PCAP_NETWORKING=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPCEM_RELDEB_AS_RELEASE=OFF -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
+                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=ON -DUSE_PCAP_NETWORKING=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPCEM_RELDEB_AS_RELEASE=OFF -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
                       artifacts_name: PCem-RelWithDebInfo-vNext-Windows-MINGW32-${{ github.run_number }}
                       artifacts_path: PCem-RelWithDebInfo-vNext-Windows-MINGW32-${{ github.run_number }}-${{ github.sha }}.zip
                       installdeps: >-
@@ -44,7 +44,7 @@ jobs:
                     - name: Windows 64bits (MSYS2)
                       os: windows-latest
                       compiler: MINGW64
-                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=OFF -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPCEM_RELDEB_AS_RELEASE=OFF -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
+                      args: -DUSE_EXPERIMENTAL=ON -DUSE_EXPERIMENTAL_PRINTER=OFF -DUSE_EXPERIMENTAL_PGC=ON -DUSE_NETWORKING=ON -DUSE_PCAP_NETWORKING=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPCEM_RELDEB_AS_RELEASE=OFF -DPCEM_VERSION_STRING="vNext build ${GITHUB_SHA::8}"
                       artifacts_name: PCem-RelWithDebInfo-vNext-Windows-MINGW64-${{ github.run_number }}
                       artifacts_path: PCem-RelWithDebInfo-vNext-Windows-MINGW64-${{ github.run_number }}-${{ github.sha }}.zip
                       installdeps: >-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ option(USE_NETWORKING "Build PCem with networking support" ON)
 message("Networking Support: ${USE_NETWORKING}")
 
 if(USE_NETWORKING)
+        set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -std=gnu17")
+        message("       Switching C to gnu17 to allow slirp to build")
+
         option(USE_PCAP_NETWORKING "Build PCem with PCAP support" ON)
         message("       PCAP Networking Support: ${USE_PCAP_NETWORKING}")
 endif()

--- a/includes/private/networking/slirp/slirp.h
+++ b/includes/private/networking/slirp/slirp.h
@@ -50,17 +50,17 @@ typedef unsigned long ioctlsockopt_t;
 
 #include <winsock2.h> //needs to be on top otherwise, it'll pull in winsock1
 #include <windows.h>
-
+#include <ws2tcpip.h>
 #include <sys/timeb.h>
 #include <iphlpapi.h>
 
 #define USE_FIONBIO 1
-#define EWOULDBLOCK WSAEWOULDBLOCK
+/*#define EWOULDBLOCK WSAEWOULDBLOCK
 #define EINPROGRESS WSAEINPROGRESS
 #define ENOTCONN WSAENOTCONN
 #define EHOSTUNREACH WSAEHOSTUNREACH
 #define ENETUNREACH WSAENETUNREACH
-#define ECONNREFUSED WSAECONNREFUSED
+#define ECONNREFUSED WSAECONNREFUSED*/
 
 /* Basilisk II Router defines those */
 #define udp_read_completion slirp_udp_read_completion

--- a/src/cpu/808x.c
+++ b/src/cpu/808x.c
@@ -525,6 +525,14 @@ void makeznptable() {
 
 int indump = 0;
 
+FILE* dofopen(const char *filepath, const char* filename, const char * mode) {
+    int c = strlen(filepath) - 1;
+    char* sep = (filepath[c] == '/' || filepath[c] == '\\') ? "" : "/";
+    char buf[1024];
+    sprintf(buf, "%s%s%s", filepath, sep, filename);
+    return fopen(buf, mode);
+}
+
 void dumpregs() {
         int c, d = 0, e = 0;
 #ifndef RELEASE_BUILD
@@ -532,74 +540,69 @@ void dumpregs() {
         if (indump)
                 return;
         indump = 1;
-        //        return;
         output = 0;
-        //        return;
-        //        savenvr();
-        //        return;
-        chdir(logs_path);
-        /*        f=fopen("rram3.dmp","wb");
+        /*        f=dofopen(logs_path, "rram3.dmp","wb");
                 for (c=0;c<0x8000000;c++) putc(readmemb(c+0x10000000),f);
                 fclose(f);*/
-        f = fopen("ram.dmp", "wb");
+        f = dofopen(logs_path, "ram.dmp", "wb");
         fwrite(ram, mem_size * 1024, 1, f);
         fclose(f);
         /*        pclog("Dumping rram5.dmp\n");
-                f=fopen("rram5.dmp","wb");
+                f=dofopen(logs_path, "rram5.dmp","wb");
                 for (c=0;c<0x1000000;c++) putc(readmemb(c+0x10150000),f);
                 fclose(f);*/
         pclog("Dumping rram.dmp\n");
-        f = fopen("rram.dmp", "wb");
+        f = dofopen(logs_path, "rram.dmp", "wb");
         for (c = 0; c < 0x1000000; c++)
                 putc(readmemb(c), f);
         fclose(f);
-        /*        f=fopen("rram2.dmp","wb");
+        /*        f=dofopen(logs_path, "rram2.dmp","wb");
                 for (c=0;c<0x100000;c++) putc(readmemb(c+0xbff00000),f);
                 fclose(f);
-                f = fopen("stack.dmp","wb");
+                f = dofopen(logs_path, "stack.dmp","wb");
                 for (c = 0; c < 0x6000; c++) putc(readmemb(c+0xFFDFA000), f);
                 fclose(f);
-                f = fopen("tempx.dmp","wb");
+                f = dofopen(logs_path, "tempx.dmp","wb");
                 for (c = 0; c < 0x10000; c++) putc(readmemb(c+0xFC816000), f);
                 fclose(f);
-                f = fopen("tempx2.dmp","wb");
+                f = dofopen(logs_path, "tempx2.dmp","wb");
                 for (c = 0; c < 0x10000; c++) putc(readmemb(c+0xFDEF5000), f);
                 fclose(f);*/
         pclog("Dumping rram4.dmp\n");
-        f = fopen("rram4.dmp", "wb");
+        f = dofopen(logs_path, "rram4.dmp", "wb");
         for (c = 0; c < 0x0050000; c++) {
                 cpu_state.abrt = 0;
                 putc(readmembl(c + 0x80000000), f);
         }
         fclose(f);
         pclog("Dumping done\n");
-/*        f=fopen("rram6.dmp","wb");
+/*        f=dofopen(logs_path, "rram6.dmp","wb");
         for (c=0;c<0x1000000;c++) putc(readmemb(c+0xBF000000),f);
         fclose(f);*/
-/*        f=fopen("ram6.bin","wb");
+/*        f=dofopen(logs_path, "ram6.bin","wb");
         fwrite(ram+0x10100,0xA000,1,f);
         fclose(f);
-        f=fopen("boot.bin","wb");
+        f=dofopen(logs_path, "boot.bin","wb");
         fwrite(ram+0x7C00,0x200,1,f);
         fclose(f);
-        f=fopen("ram7.bin","wb");
+        f=dofopen(logs_path, "ram7.bin","wb");
         fwrite(ram+0x11100,0x2000,1,f);
         fclose(f);
-        f=fopen("ram8.bin","wb");
+        f=dofopen(logs_path, "ram8.bin","wb");
         fwrite(ram+0x3D210,0x200,1,f);
         fclose(f);        */
-/*        f=fopen("bios.dmp","wb");
+/*        f=dofopen(logs_path, "bios.dmp","wb");
         fwrite(rom,0x20000,1,f);
         fclose(f);*/
-/*        f=fopen("kernel.dmp","wb");
+/*        f=dofopen(logs_path, "kernel.dmp","wb");
         for (c=0;c<0x200000;c++) putc(readmemb(c+0xC0000000),f);
         fclose(f);*/
-/*        f=fopen("rram.dmp","wb");
+/*        f=dofopen(logs_path, "rram.dmp","wb");
         for (c=0;c<0x1500000;c++) putc(readmemb(c),f);
         fclose(f);
         if (!times)
         {
-                f=fopen("thing.dmp","wb");
+                f=dofopen(logs_path, "thing.dmp","wb");
                 fwrite(ram+0x11E50,0x1000,1,f);
                 fclose(f);
         }*/

--- a/src/networking/slirp/cksum.c
+++ b/src/networking/slirp/cksum.c
@@ -76,7 +76,7 @@ int cksum(struct SLIRPmbuf *m, int len) {
         /*
          * Force to even boundary.
          */
-        if ((1 & (long)w) && (mlen > 0)) {
+        if ((1 & (off_t)w) && (mlen > 0)) {
                 REDUCE;
                 sum <<= 8;
                 s_util.c[0] = *(u_int8_t *)w;

--- a/src/networking/slirp/socket.c
+++ b/src/networking/slirp/socket.c
@@ -572,7 +572,7 @@ int flags;
             (bind(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) || (listen(s, 1) < 0)) {
                 int tmperrno = errno; /* Don't clobber the real reason we failed */
 
-                close(s);
+                closesocket(s);
                 sofree(so);
                 /* Restore the real errno */
 #ifdef _WIN32

--- a/src/networking/slirp/tftp.c
+++ b/src/networking/slirp/tftp.c
@@ -24,6 +24,8 @@
 
 #include "slirp/slirp.h"
 
+#include <stdio.h>
+
 struct tftp_session {
         int in_use;
         char filename[TFTP_FILENAME_MAX];
@@ -92,22 +94,22 @@ static int tftp_session_find(struct tftp_t *tp) {
 }
 
 static int tftp_read_data(struct tftp_session *spt, u_int16_t block_nr, u_int8_t *buf, int len) {
-        int fd;
+        FILE* file;
         int bytes_read = 0;
 
-        fd = open(spt->filename, O_RDONLY | O_BINARY);
+        file = fopen(spt->filename, "rb");
 
-        if (fd < 0) {
+        if (file == NULL) {
                 return -1;
         }
 
         if (len) {
-                lseek(fd, block_nr * 512, SEEK_SET);
+                fseek(file, block_nr * 512, SEEK_SET);
 
-                bytes_read = read(fd, buf, len);
+                bytes_read = fread(buf, len, 1, file);
         }
 
-        close(fd);
+        fclose(file);
 
         return bytes_read;
 }


### PR DESCRIPTION
- forced to build with standard "gnu17" , ( so, c17 to avoid K&R function declaration problems with slirp, and gnu because there are several classes that use assembly "with the asm" keyword).
- Changed socket.c to use socketclose instead of close, and tftpd to use stdio fopen/fseek/fread/fclose instead of posix open/lseek/read/close.
- fixed some more warnings
- removed chdir and do an absolute path fopen instead.