### PR TITLE
Add missing include for x86.

### DIFF
--- a/src/codegen/x86/codegen_backend_x86.c
+++ b/src/codegen/x86/codegen_backend_x86.c
@@ -14,6 +14,7 @@
 #if defined(__linux__) || defined(__APPLE__)
 #include <sys/mman.h>
 #include <unistd.h>
+#include <stdlib.h>
 #endif
 #if defined WIN32 || defined _WIN32 || defined _WIN32
 #include <windows.h>


### PR DESCRIPTION
On x86, it seems that `stdlib.h` needs to be included for `gcc-14.2.0` compatibility. Tested on 32-bit Slackware -current.