### PR TITLE
S3Trio64 Linear Framebuffer compute fix

### DIFF
--- a/src/video/vid_s3.c
+++ b/src/video/vid_s3.c
@@ -1317,9 +1317,16 @@ void s3_updatemapping(s3_t *s3) {
                 case 2: /*2mb*/
                         s3->linear_size = 0x200000;
                         break;
-                case 3: /*8mb*/
-                        s3->linear_size = 0x800000;
-                        break;
+                case 3: /* 4MB or 8MB depending on card maximum */
+                        switch(s3->chip) { 
+                            case S3_TRIO64: /* 4MB cards go first.... */
+                                s3->linear_size = 0x400000;
+                                break;
+                        default: /* All other S3's should be 8MB maximum */
+                                s3->linear_size = 0x800000;
+                                break;
+                    }
+                    break;
                 }
                 s3->linear_base &= ~(s3->linear_size - 1);
                 //                pclog("%08X %08X  %02X %02X %02X\n", linear_base, linear_size, crtc[0x58], crtc[0x59],


### PR DESCRIPTION
Existing code utilized an 8MB LFB size for all 4MB cards. PCem supports Vision864, which can run a maximum of 8MB memory, but all 4MB S3 cards were being given the 8MB LFB

This brings over the correct handling per Trio32/64 development manual from the 86box implementation

Noticed this while working on an Alpha/AXP emulator implementing only the Trio64 and was using various existing working implementations as references. 

Since pcem officially supports a Vision864 based card, which can have a maximum of 8MB memory, this will present a correct LFB if that option is ever added to that card and will correct Trio64 based card representations now. 