### PR TITLE
Fix for MIDI out on windows.

### DIFF
--- a/src/sound/sound.cmake
+++ b/src/sound/sound.cmake
@@ -93,7 +93,13 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND USE_ALSA)
                 sound/midi_alsa.c
                 )
         set(PCEM_ADDITIONAL_LIBS ${PCEM_ADDITIONAL_LIBS} ${ALSA_LIBRARIES})
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    set(PCEM_SRC ${PCEM_SRC}
+                sound/win-midi.c
+                )
+                set(PCEM_ADDITIONAL_LIBS ${PCEM_ADDITIONAL_LIBS} winmm)
 else()
+    message(STATUS "Warning: Using sdl2-midi. It currently is an empty midi implementation")
         set(PCEM_SRC ${PCEM_SRC}
                 sound/sdl2-midi.c
                 )


### PR DESCRIPTION
This is a fix for the issue that MIDI Out is not configurable nor working when compiling on/for windows.
Fixes #242