### PR TITLE
Fix windows packaging.

### DIFF
--- a/.github/workflows/workflow-qt.yml
+++ b/.github/workflows/workflow-qt.yml
@@ -180,7 +180,7 @@ jobs:
           ninja install
           cd $INSTALL_PREFIX
           ntldd -R "bin/pcem.exe" | sed -e 's/^[[:blank:]]*//g' | cut -d ' ' -f 3 | grep -E -i '(mingw|clang)(32|64)' | sed -e 's|\\|/|g' | xargs cp --target-directory="bin"
-          wget https://mirror.wisegs.com/pcem/libpcap.dll -O $INSTALL_PREFIX/bin/libpcap.dll
+          cp -r /mingw64/share/qt6/plugins/platforms/ $INSTALL_PREFIX/bin/platforms/
           zip -r -9 ${{ matrix.artifacts_path }} *
           cp ${{ matrix.artifacts_path }} $ARTIFACTSDIR
       - name: prepare-package (Linux)

--- a/README.md
+++ b/README.md
@@ -32,14 +32,13 @@ then `./src/pcem` to run.
 BIOS ROM images, configuration files, and other data are stored in `~/.pcem`. You can also create a `.pcem` folder with
 the Binary, and run it in a portable mode.
 
-You can specify the Display Engine using `-DPCEM_DISPLAY_ENGINE=` The only valid option you have at this time is
-wxWidgets 
-
 The configure options are specified below. They are in the format of -D`Option`=`Value`. `Value` under here is the
 default value.
 ```
   -DCMAKE_BUILD_TYPE=Release : Generate release build. Recommended for regular use.
   -DCMAKE_BUILD_TYPE=Debug   : Compile with debugging enabled.
+  -DPCEM_DISPLAY_ENGINE=wxWidgets : Compile with the WxWidgets Display Engine. Default
+  -DPCEM_DISPLAY_ENGINE=Qt   : Compile with the Qt Display Engine.
   -DUSE_NETWORKING=ON        : Build with networking support.
   -DUSE_PCAP_NETWORKING=ON   : Build with pcap networking support. (Needs USE_NETWORKING to compile) Requires libpcap.
   -DUSE_ALSA=OFF             : Build with support for MIDI output through ALSA. Requires libasound. (Linux Only)
@@ -76,6 +75,8 @@ The menu is a pop-up menu in the Linux/BSD port. Right-click on the main window 
 captured.
 
 CD-ROM support currently only accesses `/dev/cdrom`. It has not been heavily tested.
+
+On Windows, if you want to use PCAP networking, you will need to install [npcap](https://npcap.com) and replace the libpcap.dll in PCem dir using the wpcap.dll installed in C:\Windows\System32  
 
 ## Links
 

--- a/experimental/printer_epsonlx810/CMakeLists.txt
+++ b/experimental/printer_epsonlx810/CMakeLists.txt
@@ -12,5 +12,5 @@ set(EPSON_LX810_SRC
         )
 
 add_library(printer_epsonlx810 SHARED ${EPSON_LX810_SRC} ${EPSON_LX810_HEADER})
-target_link_libraries(printer_epsonlx810 ${PCEM_LIBRARIES} Freetype::Freetype)
+target_link_libraries(printer_epsonlx810 PRIVATE ${PCEM_LIBRARIES} Freetype::Freetype)
 set_target_properties(printer_epsonlx810 PROPERTIES SUFFIX ".pplg")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,14 +75,18 @@ set(PCEM_LIBRARIES ${DISPLAY_ENGINE_LIBRARIES} ${SDL2_LIBRARIES} ${OPENAL_LIBRAR
 include(${CMAKE_CURRENT_SOURCE_DIR}/plugin-api/plugin-api.cmake)
 
 set(PCEM_LIBRARIES ${PCEM_LIBRARIES} PARENT_SCOPE)
-
+if(${PCEM_DISPLAY_ENGINE} STREQUAL "Qt")
+qt_add_executable(pcem ${PCEM_SRC} ${PCEM_PRIVATE_API} ${PCEM_EMBEDDED_PLUGIN_API})
+endif()
+if(${PCEM_DISPLAY_ENGINE} STREQUAL "wxWidgets")
 add_executable(pcem ${PCEM_SRC} ${PCEM_PRIVATE_API} ${PCEM_EMBEDDED_PLUGIN_API})
+endif()
 target_compile_definitions(pcem PUBLIC ${PCEM_DEFINES})
 target_compile_options(pcem PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-fno-common> $<$<COMPILE_LANGUAGE:C>:-fno-common>)
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
         target_link_options(pcem PRIVATE "-Wl,--subsystem,windows")
 endif()
-target_link_libraries(pcem ${PCEM_LIBRARIES})
+target_link_libraries(pcem PRIVATE ${PCEM_LIBRARIES})
 
 # Disable Qt6 UNICODE defines - PCem uses ANSI (char*) Win32 APIs
 if(PCEM_QT_NO_UNICODE)

--- a/src/qt-ui/qt-ui.cmake
+++ b/src/qt-ui/qt-ui.cmake
@@ -9,10 +9,10 @@ set(PCEM_PRIVATE_API ${PCEM_PRIVATE_API}
         ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-glslp-parser.h
         ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-hostconfig.h
         ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-joystickconfig.h
-        ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-sdl2-glw.h
         ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-sdl2.h
-        ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-sdl2-video-gl3.h
+        ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-sdl2-glw.h
         ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-sdl2-video.h
+        ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-sdl2-video-gl3.h
         ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-sdl2-video-renderer.h
         ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-shaderconfig.h
         ${CMAKE_SOURCE_DIR}/includes/private/qt-ui/qt-status.h
@@ -20,30 +20,39 @@ set(PCEM_PRIVATE_API ${PCEM_PRIVATE_API}
         )
 
 set(PCEM_SRC ${PCEM_SRC}
-        qt-ui/qt-main.cc
         qt-ui/qt-app.cc
-        qt-ui/qt-utils.cc
-        qt-ui/qt-dialogbox.cc
-        qt-ui/qt-status.cc
-        qt-ui/qt-config_sel.c
-        qt-ui/qt-config.c
         qt-ui/qt-common.c
-        qt-ui/qt-deviceconfig.cc
-        qt-ui/qt-joystickconfig.cc
-        qt-ui/qt-shaderconfig.cc
-        qt-ui/qt-createdisc.cc
+        qt-ui/qt-config.c
+        qt-ui/qt-config_sel.c
         qt-ui/qt-config-eventbinder.cc
+        qt-ui/qt-createdisc.cc
+        qt-ui/qt-deviceconfig.cc
+        qt-ui/qt-dialogbox.cc
+        qt-ui/qt-glslp-parser.c
+        qt-ui/qt-joystickconfig.cc
+        qt-ui/qt-main.cc
         qt-ui/qt-sdl2.c
         qt-ui/qt-sdl2-joystick.c
-        qt-ui/qt-sdl2-mouse.c
         qt-ui/qt-sdl2-keyboard.c
-        qt-ui/qt-sdl2-video.c
+        qt-ui/qt-sdl2-mouse.c
         qt-ui/qt-sdl2-status.c
-        qt-ui/qt-thread.c
-        qt-ui/qt-sdl2-video-renderer.c
+        qt-ui/qt-sdl2-video.c
         qt-ui/qt-sdl2-video-gl3.c
-        qt-ui/qt-glslp-parser.c
+        qt-ui/qt-sdl2-video-renderer.c
         qt-ui/qt-shader_man.c
+        qt-ui/qt-shaderconfig.cc
+        qt-ui/qt-status.cc
+        qt-ui/qt-thread.c
+        qt-ui/qt-utils.cc
+		qt-ui/AboutDlg.ui
+		qt-ui/ConfigureDlg.ui
+		qt-ui/ConfigureSelectionDlg.ui
+		qt-ui/ConfirmRememberDlg.ui
+		qt-ui/CustomResolutionDlg.ui
+		qt-ui/HdNewDlg.ui
+		qt-ui/HdSizeDlg.ui
+		qt-ui/HostConfig.ui
+		qt-ui/ShaderManagerDlg.ui
         )
 
 if(USE_NETWORKING)


### PR DESCRIPTION
The new Qt build requires a platform dll from Qt copied to the binary folder. 
Also, the libnpcap.dll provided previously required to install npcap even if not using npcap (the application wouldn't start due to missing packet.dll). 
Restored to use the older libnpcap from msys2, and adding a comment to the README on how to use NPCAP on windows.